### PR TITLE
Fix absolute path to bower components in index

### DIFF
--- a/name
+++ b/name
@@ -50,9 +50,9 @@
     <% if (elementVersion === '1.x') { %>
     <link rel="import" href="bower_components/iron-component-page/iron-component-page.html">
     <% } else if (elementVersion === '2.0') { %>
-    <script src="/bower_components/custom-elements/custom-elements.min.js"></script>
+    <script src="bower_components/custom-elements/custom-elements.min.js"></script>
     <% } else if (elementVersion === 'vanilla') { %>
-    <script src="/bower_components/custom-elements/dist/CustomElements.min.js"></script>
+    <script src="bower_components/custom-elements/dist/CustomElements.min.js"></script>
     <% } %>
 
 
@@ -80,7 +80,7 @@
     <% } else if ( elementVersion === '2.0' ) { %>
 
       <% if ( elementType === 'component' ) { %>
-        <!-- 
+        <!--
         Swap the component page in for the demo when the 2.0 version of the component is ready.
         <iron-component-page src="bower_components/<%=elementName%>/<%=elementName%>.html" active="<%=elementName%>"></iron-component-page>
         -->
@@ -111,9 +111,9 @@
       <% } else if ( elementType === 'behavior' ) { %>
         <div>This is the place for a vanilla behavior</div>
       <% } %>
-    
+
     <% } %>
-       
+
 
 
 


### PR DESCRIPTION
## PR Name

### Status
<!--  -->
- [x] **IN REVIEW** :yellow_heart:
- [ ] **READY TO MERGE** :green_heart:

### Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
The generator has an incorrect path for loading the webcomponents.js shims, so the documentation and demos pages don't work when the shims are needed.

### Issues Addressed
<!-- All the issues that this PR is attempting to solve in a checklist. -->
<!-- Reference with pound sign notation and check as complete. emoji optional -->

 - [x] # :bug:      (bugfix)

### Testable outcomes
<!-- Help out QA and let them know what they should be seeing, or shouldn't be seeing -->
<!-- Inline changes or link to issues -->
- [x] Elements generated going forward have working documentation and demos in Firefox, Safari, IE, etc.

#### Sign off
<!-- These are the last things that need to happen in order for the code to get pushed out. -->

- [x] [code review]() by @
<!-- There are the potential for multiple code reviews within github. and this thread could get long
add a link to the review along with your name for easy reference. -->
- [x] tested by @
- [x] good to go! :squirrel:
